### PR TITLE
Replace short array syntax definitions

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,16 +7,16 @@
 	
 	$dataBase = "SQLite";
 	//only for SQLite
-	$SQLiteConfig = [
+	$SQLiteConfig = array(
         'file' => "shoppinglist.sqlite",
-	];
+	);
 	//only for MySQL
-	$MySQLConfig = [
+	$MySQLConfig = array(
         'host' => "host",
         'db' => "db",
         'user' => "user",
         'password' => "password",
-    ];
+    );
     
     if($argc > 1){
 		echo password_hash($argv[1], PASSWORD_BCRYPT);

--- a/sqlite_connector.php
+++ b/sqlite_connector.php
@@ -24,20 +24,20 @@
          
         function listall(){
             $resultQuery = $this->db->query("SELECT ITEM, COUNT FROM itemlist ORDER BY ITEM ASC;");
-            $stack = [];
+            $stack = array();
             if(!$resultQuery){
-                $dummy = [
+                $dummy = array(
                     'item' => "",
                     'count' => 0,
-                ];
+                );
                 array_push($stack, $dummy);
                 return $stack;
             }
             while($item = $resultQuery->fetchArray()){
-                $itemData = [
+                $itemData = array(
                     'item' => $item['ITEM'],
                     'count' => $item['COUNT'],
-                ];
+                );
                 array_push($stack, $itemData);
             }
             return json_encode($stack);


### PR DESCRIPTION
The short array syntax appeares first in PHP 5.4.0, but this backend requirement is PHP 5.3.7 only.
Note that you can still easily find 5.3.X PHP instances in production (Ubuntu 12.04 LTS for example packages PHP 5.3.10).
